### PR TITLE
feat: Add Cert DCV Scope to Order type

### DIFF
--- a/order.go
+++ b/order.go
@@ -84,6 +84,7 @@ type (
 		Domains                     []Domain           `json:"domains,omitempty"`
 		CertificateID               int                `json:"certificate_id,omitempty"`
 		CertificateChain            []CertificateChain `json:"certificate_chain,omitempty"`
+		CertificateDCVScope         string             `json:"certificate_dcv_scope,omitempty"`
 		Container                   *Container         `json:"container,omitempty"`
 		DateCreated                 time.Time          `json:"date_created,omitempty"`
 		Status                      string             `json:"status,omitempty"`


### PR DESCRIPTION
Add a new Order field to specify `certificate_dcv_scope`. This can be used when creating DigiCert order as defined in [API documentation](https://dev.digicert.com/en/certcentral-apis/services-api/orders/order-ov-ev-ssl.html).